### PR TITLE
Add dockerfile and run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,23 @@ The `_item_diff` fields contain the diff for that item between the two responses
 }
 ```
 
+### Running in Docker
+There is also a docker file that sets up the traffic comparator and listens for incoming `triples`.
+It's set up in a slightly unorthodox way. Instead of copying the module files in and installing them
+while creating the image, that instead happens while running the container. This has the advantage of
+very quick editability, at the expense of more expensive container starts with more dependencies.
+
+To build the image:
+```
+cd <path_to_repo>
+docker build -t trafficcomparator docker
+```
+
+To run the image:
+```
+docker run -v <path_to_repo>:/traffic_comparator -p 9220:9220 -it trafficcomparator
+```
+
 ## Working on the Traffic Comparator
 
 To install dev dependencies (e.g. flake8 and pytest):

--- a/README.md
+++ b/README.md
@@ -173,19 +173,16 @@ The `_item_diff` fields contain the diff for that item between the two responses
 
 ### Running in Docker
 There is also a docker file that sets up the traffic comparator and listens for incoming `triples`.
-It's set up in a slightly unorthodox way. Instead of copying the module files in and installing them
-while creating the image, that instead happens while running the container. This has the advantage of
-very quick editability, at the expense of more expensive container starts with more dependencies.
 
-To build the image:
+To build the image, run `docker build` but set the build context to the main repo directory:
 ```
 cd <path_to_repo>
-docker build -t trafficcomparator docker
+docker build -t trafficcomparator -f docker/Dockerfile .
 ```
 
 To run the image:
 ```
-docker run -v <path_to_repo>:/traffic_comparator -p 9220:9220 -it trafficcomparator
+docker run -p 9220:9220 -it trafficcomparator
 ```
 
 ## Working on the Traffic Comparator

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,10 +4,14 @@ FROM python:3.10.10
 RUN apt-get update && apt-get install -y netcat
 
 WORKDIR /traffic_comparator
+RUN mkdir /traffic_comparator/traffic_comparator
+COPY traffic_comparator /traffic_comparator/traffic_comparator/
+COPY setup.py /traffic_comparator/
+COPY cli.py /traffic_comparator/
 
-# Copying the local necessary files for the comparator to run is only temporary, until the comparator repo is public.
-# Then the steps here would be to clone the repo.
-VOLUME /traffic_comparator
+COPY docker/run_app.sh ./run_app.sh
 
-CMD docker/run_app.sh
+RUN pip3 install --editable .
+
+CMD ./run_app.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+FROM python:3.10.10
+
+RUN apt-get update && apt-get install -y netcat
+
+WORKDIR /traffic_comparator
+
+# Copying the local necessary files for the comparator to run is only temporary, until the comparator repo is public.
+# Then the steps here would be to clone the repo.
+VOLUME /traffic_comparator
+
+CMD docker/run_app.sh
+

--- a/docker/run_app.sh
+++ b/docker/run_app.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-pip install -e .
 while true
 do
   nc -v -l -p 9220 | tee /dev/stderr | trafficcomparator -vv stream | trafficcomparator stream-report

--- a/docker/run_app.sh
+++ b/docker/run_app.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+pip install -e .
+while true
+do
+  nc -v -l -p 9220 | tee /dev/stderr | trafficcomparator -vv stream | trafficcomparator stream-report
+  >&2 echo "Command has encountered error. Restarting now ..."
+  sleep 1
+done
+


### PR DESCRIPTION
Signed-off-by: Mikayla Thompson <thomika@amazon.com>
### Description
This is an alternative version of #1 . It takes a more traditional approach to a dockerfile, because I think this will be significantly easier to run in fargate and still allows the files to be locally editable (i.e. it's not pulling the repo from gh).

Example command to build, run and send data:
```
cd <path_to_repo>
docker build -t trafficcomparator -f docker/Dockerfile .
docker run -p 9220:9220 -it trafficcomparator
cat tiny_triples.json | nc -v 127.0.0.1 9220
```

### Testing
Manual

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check 
[here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
